### PR TITLE
libnativebridge: shorten test names

### DIFF
--- a/run/test/libnativebridge/CodeCacheCreate.run
+++ b/run/test/libnativebridge/CodeCacheCreate.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_CodeCacheCreate">
+	<start name="test_CodeCacheCreate">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_CodeCacheCreate
+	test_CodeCacheCreate
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_CodeCacheCreate" exited with exit value 0} $timeout
+run_genode_until {.*child "test_CodeCacheCreate" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/CodeCacheExists.run
+++ b/run/test/libnativebridge/CodeCacheExists.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_CodeCacheExists">
+	<start name="test_CodeCacheExists">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_CodeCacheExists
+	test_CodeCacheExists
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_CodeCacheExists" exited with exit value 0} $timeout
+run_genode_until {.*child "test_CodeCacheExists" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/CodeCacheStatFail.run
+++ b/run/test/libnativebridge/CodeCacheStatFail.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_CodeCacheStatFail">
+	<start name="test_CodeCacheStatFail">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_CodeCacheStatFail
+	test_CodeCacheStatFail
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_CodeCacheStatFail" exited with exit value 0} $timeout
+run_genode_until {.*child "test_CodeCacheStatFail" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/CompleteFlow.run
+++ b/run/test/libnativebridge/CompleteFlow.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_CompleteFlow">
+	<start name="test_CompleteFlow">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_CompleteFlow
+	test_CompleteFlow
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_CompleteFlow" exited with exit value 0} $timeout
+run_genode_until {.*child "test_CompleteFlow" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/InvalidCharsNativeBridge.run
+++ b/run/test/libnativebridge/InvalidCharsNativeBridge.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_InvalidCharsNativeBridge">
+	<start name="test_InvalidCharsNativeBridge">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_InvalidCharsNativeBridge
+	test_InvalidCharsNativeBridge
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_InvalidCharsNativeBridge" exited with exit value 0} $timeout
+run_genode_until {.*child "test_InvalidCharsNativeBridge" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/NativeBridge3CreateNamespace.run
+++ b/run/test/libnativebridge/NativeBridge3CreateNamespace.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_NativeBridge3CreateNamespace">
+	<start name="test_NativeBridge3CreateNamespace">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_NativeBridge3CreateNamespace
+	test_NativeBridge3CreateNamespace
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_NativeBridge3CreateNamespace" exited with exit value 0} $timeout
+run_genode_until {.*child "test_NativeBridge3CreateNamespace" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/NativeBridge3GetError.run
+++ b/run/test/libnativebridge/NativeBridge3GetError.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_NativeBridge3GetError">
+	<start name="test_NativeBridge3GetError">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_NativeBridge3GetError
+	test_NativeBridge3GetError
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_NativeBridge3GetError" exited with exit value 0} $timeout
+run_genode_until {.*child "test_NativeBridge3GetError" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/NativeBridge3IsPathSupported.run
+++ b/run/test/libnativebridge/NativeBridge3IsPathSupported.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_NativeBridge3IsPathSupported">
+	<start name="test_NativeBridge3IsPathSupported">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_NativeBridge3IsPathSupported
+	test_NativeBridge3IsPathSupported
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_NativeBridge3IsPathSupported" exited with exit value 0} $timeout
+run_genode_until {.*child "test_NativeBridge3IsPathSupported" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/NativeBridge3LoadLibraryExt.run
+++ b/run/test/libnativebridge/NativeBridge3LoadLibraryExt.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_NativeBridge3LoadLibraryExt">
+	<start name="test_NativeBridge3LoadLibraryExt">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_NativeBridge3LoadLibraryExt
+	test_NativeBridge3LoadLibraryExt
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_NativeBridge3LoadLibraryExt" exited with exit value 0} $timeout
+run_genode_until {.*child "test_NativeBridge3LoadLibraryExt" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/NativeBridge3UnloadLibrary.run
+++ b/run/test/libnativebridge/NativeBridge3UnloadLibrary.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_NativeBridge3UnloadLibrary">
+	<start name="test_NativeBridge3UnloadLibrary">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_NativeBridge3UnloadLibrary
+	test_NativeBridge3UnloadLibrary
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_NativeBridge3UnloadLibrary" exited with exit value 0} $timeout
+run_genode_until {.*child "test_NativeBridge3UnloadLibrary" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/NativeBridgeVersion.run
+++ b/run/test/libnativebridge/NativeBridgeVersion.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_NativeBridgeVersion">
+	<start name="test_NativeBridgeVersion">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_NativeBridgeVersion
+	test_NativeBridgeVersion
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_NativeBridgeVersion" exited with exit value 0} $timeout
+run_genode_until {.*child "test_NativeBridgeVersion" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/NeedsNativeBridge.run
+++ b/run/test/libnativebridge/NeedsNativeBridge.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_NeedsNativeBridge">
+	<start name="test_NeedsNativeBridge">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_NeedsNativeBridge
+	test_NeedsNativeBridge
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_NeedsNativeBridge" exited with exit value 0} $timeout
+run_genode_until {.*child "test_NeedsNativeBridge" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/PreInitializeNativeBridge.run
+++ b/run/test/libnativebridge/PreInitializeNativeBridge.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_PreInitializeNativeBridge">
+	<start name="test_PreInitializeNativeBridge">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_PreInitializeNativeBridge
+	test_PreInitializeNativeBridge
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_PreInitializeNativeBridge" exited with exit value 0} $timeout
+run_genode_until {.*child "test_PreInitializeNativeBridge" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/PreInitializeNativeBridgeFail1.run
+++ b/run/test/libnativebridge/PreInitializeNativeBridgeFail1.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_PreInitializeNativeBridgeFail1">
+	<start name="test_PreInitializeNativeBridgeFail1">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_PreInitializeNativeBridgeFail1
+	test_PreInitializeNativeBridgeFail1
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_PreInitializeNativeBridgeFail1" exited with exit value 0} $timeout
+run_genode_until {.*child "test_PreInitializeNativeBridgeFail1" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/PreInitializeNativeBridgeFail2.run
+++ b/run/test/libnativebridge/PreInitializeNativeBridgeFail2.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_PreInitializeNativeBridgeFail2">
+	<start name="test_PreInitializeNativeBridgeFail2">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_PreInitializeNativeBridgeFail2
+	test_PreInitializeNativeBridgeFail2
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_PreInitializeNativeBridgeFail2" exited with exit value 0} $timeout
+run_genode_until {.*child "test_PreInitializeNativeBridgeFail2" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/ReSetupNativeBridge.run
+++ b/run/test/libnativebridge/ReSetupNativeBridge.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_ReSetupNativeBridge">
+	<start name="test_ReSetupNativeBridge">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_ReSetupNativeBridge
+	test_ReSetupNativeBridge
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_ReSetupNativeBridge" exited with exit value 0} $timeout
+run_genode_until {.*child "test_ReSetupNativeBridge" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/UnavailableNativeBridge.run
+++ b/run/test/libnativebridge/UnavailableNativeBridge.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_UnavailableNativeBridge">
+	<start name="test_UnavailableNativeBridge">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_UnavailableNativeBridge
+	test_UnavailableNativeBridge
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_UnavailableNativeBridge" exited with exit value 0} $timeout
+run_genode_until {.*child "test_UnavailableNativeBridge" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/ValidNameNativeBridge.run
+++ b/run/test/libnativebridge/ValidNameNativeBridge.run
@@ -5,7 +5,7 @@ append build_components {
 }
 
 append config {
-	<start name="libnativebridge_ValidNameNativeBridge">
+	<start name="test_ValidNameNativeBridge">
 		<resource name="RAM" quantum="4M"/>
 		<config>
 			<vfs>
@@ -18,9 +18,9 @@ append config {
 }
 
 append boot_modules {
-	libnativebridge_ValidNameNativeBridge
+	test_ValidNameNativeBridge
 }
 
 source ${genode_dir}/repos/componolit/run/test/libnativebridge/build.inc
 
-run_genode_until {.*child "libnativebridge_ValidNameNativeBridge" exited with exit value 0} $timeout
+run_genode_until {.*child "test_ValidNameNativeBridge" exited with exit value 0} $timeout

--- a/run/test/libnativebridge/variables.inc
+++ b/run/test/libnativebridge/variables.inc
@@ -23,7 +23,7 @@ set config {
 	<default-route>
 		<any-service> <parent/> <any-child/> </any-service>
 	</default-route>
-	<default caps="100"/>
+	<default caps="200"/>
 
 	<start name="timer">
 		<resource name="RAM" quantum="1M"/>

--- a/src/test/libnativebridge/CodeCacheCreate/target.mk
+++ b/src/test/libnativebridge/CodeCacheCreate/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_CodeCacheCreate
+TARGET = test_CodeCacheCreate
 SRC_CC = CodeCacheCreate_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/CodeCacheExists/target.mk
+++ b/src/test/libnativebridge/CodeCacheExists/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_CodeCacheExists
+TARGET = test_CodeCacheExists
 SRC_CC = CodeCacheExists_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/CodeCacheStatFail/target.mk
+++ b/src/test/libnativebridge/CodeCacheStatFail/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_CodeCacheStatFail
+TARGET = test_CodeCacheStatFail
 SRC_CC = CodeCacheStatFail_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/CompleteFlow/target.mk
+++ b/src/test/libnativebridge/CompleteFlow/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_CompleteFlow
+TARGET = test_CompleteFlow
 SRC_CC = CompleteFlow_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/InvalidCharsNativeBridge/target.mk
+++ b/src/test/libnativebridge/InvalidCharsNativeBridge/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_InvalidCharsNativeBridge
+TARGET = test_InvalidCharsNativeBridge
 SRC_CC = InvalidCharsNativeBridge_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/NativeBridge3CreateNamespace/target.mk
+++ b/src/test/libnativebridge/NativeBridge3CreateNamespace/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_NativeBridge3CreateNamespace
+TARGET = test_NativeBridge3CreateNamespace
 SRC_CC = NativeBridge3CreateNamespace_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/NativeBridge3GetError/target.mk
+++ b/src/test/libnativebridge/NativeBridge3GetError/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_NativeBridge3GetError
+TARGET = test_NativeBridge3GetError
 SRC_CC = NativeBridge3GetError_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/NativeBridge3IsPathSupported/target.mk
+++ b/src/test/libnativebridge/NativeBridge3IsPathSupported/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_NativeBridge3IsPathSupported
+TARGET = test_NativeBridge3IsPathSupported
 SRC_CC = NativeBridge3IsPathSupported_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/NativeBridge3LoadLibraryExt/target.mk
+++ b/src/test/libnativebridge/NativeBridge3LoadLibraryExt/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_NativeBridge3LoadLibraryExt
+TARGET = test_NativeBridge3LoadLibraryExt
 SRC_CC = NativeBridge3LoadLibraryExt_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/NativeBridge3UnloadLibrary/target.mk
+++ b/src/test/libnativebridge/NativeBridge3UnloadLibrary/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_NativeBridge3UnloadLibrary
+TARGET = test_NativeBridge3UnloadLibrary
 SRC_CC = NativeBridge3UnloadLibrary_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/NativeBridgeVersion/target.mk
+++ b/src/test/libnativebridge/NativeBridgeVersion/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_NativeBridgeVersion
+TARGET = test_NativeBridgeVersion
 SRC_CC = NativeBridgeVersion_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/NeedsNativeBridge/target.mk
+++ b/src/test/libnativebridge/NeedsNativeBridge/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_NeedsNativeBridge
+TARGET = test_NeedsNativeBridge
 SRC_CC = NeedsNativeBridge_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/PreInitializeNativeBridge/target.mk
+++ b/src/test/libnativebridge/PreInitializeNativeBridge/target.mk
@@ -1,6 +1,5 @@
-TARGET = libnativebridge_PreInitializeNativeBridge
+TARGET = test_PreInitializeNativeBridge
 SRC_CC = PreInitializeNativeBridge_test.cpp
 
 CC_OPT = -D__ANDROID__
 include $(REP_DIR)/src/test/libnativebridge/target.inc
-

--- a/src/test/libnativebridge/PreInitializeNativeBridgeFail1/target.mk
+++ b/src/test/libnativebridge/PreInitializeNativeBridgeFail1/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_PreInitializeNativeBridgeFail1
+TARGET = test_PreInitializeNativeBridgeFail1
 SRC_CC = PreInitializeNativeBridgeFail1_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/PreInitializeNativeBridgeFail2/target.mk
+++ b/src/test/libnativebridge/PreInitializeNativeBridgeFail2/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_PreInitializeNativeBridgeFail2
+TARGET = test_PreInitializeNativeBridgeFail2
 SRC_CC = PreInitializeNativeBridgeFail2_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/ReSetupNativeBridge/target.mk
+++ b/src/test/libnativebridge/ReSetupNativeBridge/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_ReSetupNativeBridge
+TARGET = test_ReSetupNativeBridge
 SRC_CC = ReSetupNativeBridge_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/UnavailableNativeBridge/target.mk
+++ b/src/test/libnativebridge/UnavailableNativeBridge/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_UnavailableNativeBridge
+TARGET = test_UnavailableNativeBridge
 SRC_CC = UnavailableNativeBridge_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 

--- a/src/test/libnativebridge/ValidNameNativeBridge/target.mk
+++ b/src/test/libnativebridge/ValidNameNativeBridge/target.mk
@@ -1,4 +1,4 @@
-TARGET = libnativebridge_ValidNameNativeBridge
+TARGET = test_ValidNameNativeBridge
 SRC_CC = ValidNameNativeBridge_test.cpp
 include $(REP_DIR)/src/test/libnativebridge/target.inc
 


### PR DESCRIPTION
ROM file names must not exceed 39 characters on base-linux